### PR TITLE
[G2P-3503] Remove 'other' registry type from registry addons baseline

### DIFF
--- a/g2p_registry_type_addon/models/registry_type.py
+++ b/g2p_registry_type_addon/models/registry_type.py
@@ -19,7 +19,6 @@ class G2PTargetModelMapping:
 class G2PRegistryType(Enum):
     FARMER = "farmer"
     STUDENT = "student"
-    OTHER = "other"
 
     @classmethod
     def selection(cls):


### PR DESCRIPTION
[G2P-3503](https://openg2p.atlassian.net/browse/G2P-3503)

[G2P-3503]: https://openg2p.atlassian.net/browse/G2P-3503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ