### PR TITLE
Update household model name and views to match registry table

### DIFF
--- a/g2p_registry_addon/models/household.py
+++ b/g2p_registry_addon/models/household.py
@@ -4,7 +4,7 @@ from .registry import G2PRegistry
 
 
 class G2PRegisterHousehold(models.Model):
-    _name = "g2p.register.household"
+    _name = "g2p.register.households"
     _description = "Register Household"
     _inherit = "g2p.registry"
 

--- a/g2p_registry_addon/security/ir.model.access.csv
+++ b/g2p_registry_addon/security/ir.model.access.csv
@@ -5,5 +5,5 @@ g2p_farmer_registry_read,Read Farmer Registry,model_g2p_farmer_registry,g2p_pbms
 g2p_farmer_registry_write,Write Farmer Registry,model_g2p_farmer_registry,g2p_pbms.group_beneficiary_list_editor,1,1,1,1
 g2p_register_families_read,Read Register Families,model_g2p_register_families,g2p_pbms.group_beneficiary_list_viewer,1,0,0,0
 g2p_register_families_write,Write Register Families,model_g2p_register_families,g2p_pbms.group_beneficiary_list_editor,1,1,1,1
-g2p_register_household_read,Read Register Household,model_g2p_register_household,g2p_pbms.group_beneficiary_list_viewer,1,0,0,0
-g2p_register_household_write,Write Register Household,model_g2p_register_household,g2p_pbms.group_beneficiary_list_editor,1,1,1,1
+g2p_register_household_read,Read Register Household,model_g2p_register_households,g2p_pbms.group_beneficiary_list_viewer,1,0,0,0
+g2p_register_household_write,Write Register Household,model_g2p_register_households,g2p_pbms.group_beneficiary_list_editor,1,1,1,1

--- a/g2p_registry_addon/views/bgtask/bgtask_view.xml
+++ b/g2p_registry_addon/views/bgtask/bgtask_view.xml
@@ -10,7 +10,7 @@
           <widget name="g2p_beneficiaries_widget" model="g2p.register.families" id="farmer_beneficiary_search_widget"/>
         </group> -->
         <group name="beneficiary_search_household" invisible="target_registry != 'household'">
-          <widget name="g2p_beneficiaries_widget" model="g2p.register.household" id="household_beneficiary_search_widget"/>
+          <widget name="g2p_beneficiaries_widget" model="g2p.register.households" id="household_beneficiary_search_widget"/>
         </group>
         <!-- <group name="beneficiary_search_family_members" invisible="target_registry != 'family_members'">
           <widget name="g2p_beneficiaries_widget" model="g2p.register.family.members" id="family_members_beneficiary_search_widget"/>

--- a/g2p_registry_addon/views/eligibility/eligibility_rule_view.xml
+++ b/g2p_registry_addon/views/eligibility/eligibility_rule_view.xml
@@ -11,7 +11,7 @@
 
                 <!-- Domain widget for the 'household' type -->
                 <field name="pbms_domain" widget="domain"
-                       options="{'model': 'g2p.register.household'}"
+                       options="{'model': 'g2p.register.households'}"
                        invisible="target_registry != 'household'"/>
 
                 <!-- Domain widget for the 'family_members' type -->

--- a/g2p_registry_addon/views/entitlement/entitlement_rule_view.xml
+++ b/g2p_registry_addon/views/entitlement/entitlement_rule_view.xml
@@ -11,7 +11,7 @@
 
                 <!-- Domain widget for the 'household' type -->
                 <field name="pbms_domain" widget="domain"
-                       options="{'model': 'g2p.register.household'}"
+                       options="{'model': 'g2p.register.households'}"
                        invisible="target_registry != 'household'"/>
 
                 <!-- Domain widget for the 'family_members' type -->

--- a/g2p_registry_addon/views/priority/priority_rule_view.xml
+++ b/g2p_registry_addon/views/priority/priority_rule_view.xml
@@ -11,7 +11,7 @@
 
                 <!-- Domain widget for the 'household' type -->
                 <field name="pbms_domain" widget="domain"
-                       options="{'model': 'g2p.register.household', 'allowed_fields': ['priority_rank']}"
+                       options="{'model': 'g2p.register.households', 'allowed_fields': ['priority_rank']}"
                        invisible="target_registry != 'household'"/>
 
                 <!-- Domain widget for the 'family_members' type -->

--- a/g2p_registry_addon/views/registry/household_registry_view.xml
+++ b/g2p_registry_addon/views/registry/household_registry_view.xml
@@ -2,13 +2,13 @@
 <odoo>
     <record id="action_g2p_register_household" model="ir.actions.act_window">
         <field name="name">Register Household</field>
-        <field name="res_model">g2p.register.household</field>
+        <field name="res_model">g2p.register.households</field>
         <field name="view_mode">tree,form</field>
     </record>
 
     <record id="view_g2p_register_household_form" model="ir.ui.view">
-        <field name="name">g2p.register.household.form</field>
-        <field name="model">g2p.register.household</field>
+        <field name="name">g2p.register.households.form</field>
+        <field name="model">g2p.register.households</field>
         <field name="arch" type="xml">
             <form string="G2P Register Household" create="0">
                 <sheet>
@@ -66,8 +66,8 @@
     </record>
 
     <record id="view_g2p_register_household_tree" model="ir.ui.view">
-        <field name="name">g2p.register.household.tree</field>
-        <field name="model">g2p.register.household</field>
+        <field name="name">g2p.register.households.tree</field>
+        <field name="model">g2p.register.households</field>
         <field name="arch" type="xml">
             <tree string="G2P Register Household" create="0">
                 <field name="internal_record_id"/>

--- a/g2p_registry_type_addon/models/registry_type.py
+++ b/g2p_registry_type_addon/models/registry_type.py
@@ -8,7 +8,7 @@ class G2PTargetModelMapping:
         "student": "g2p.student.registry",
         "farmer": "g2p.farmer.registry",
         "families": "g2p.register.families",
-        "household": "g2p.register.household"
+        "household": "g2p.register.households"
     }
 
     @classmethod


### PR DESCRIPTION
- Renamed model from 'g2p.register.household' to 'g2p.register.households' across various files.
- Updated access rights in ir.model.access.csv to reflect the new model name.
- Adjusted widget and domain references in view files to use the updated model name.